### PR TITLE
Fix data race in RandString

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -2,18 +2,30 @@ package helpers
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 )
 
-var rnd = rand.New(rand.NewSource(time.Now().Unix()))
+// rnd is guarded by rndMu: rand.New returns a generator that is not safe for
+// concurrent use, unlike the top-level functions of math/rand. RandString is
+// called from LogPackage.Chunkify on every log record, and applications log
+// from several goroutines at once.
+var (
+	rndMu sync.Mutex
+	rnd   = rand.New(rand.NewSource(time.Now().Unix()))
+)
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 func RandString(n int) string {
 	b := make([]byte, n)
+
+	rndMu.Lock()
 	for i := range b {
 		b[i] = letterBytes[rnd.Intn(len(letterBytes))]
 	}
+	rndMu.Unlock()
+
 	return string(b)
 }
 

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestRandStringConcurrent ловит гонку на общем генераторе случайных чисел.
+// RandString вызывается из LogPackage.Chunkify, то есть на каждой записи лога,
+// а логи в приложении пишут разные горутины одновременно.
+//
+// Без синхронизации падает под -race.
+func TestRandStringConcurrent(t *testing.T) {
+	const goroutines = 8
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if got := RandString(6); len(got) != 6 {
+					t.Errorf("RandString(6) = %q, want 6 chars", got)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/tests/ConcurrentLogger_test.go
+++ b/tests/ConcurrentLogger_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	logr "github.com/504dev/logr-go-client"
+)
+
+// TestLoggerConcurrentWrites checks that a logger can be written to from several
+// goroutines, which is how applications use it: workers, HTTP handlers and
+// background loops all log through the same instance.
+//
+// Nothing listens on the UDP address — the transport only needs to be dialable.
+func TestLoggerConcurrentWrites(t *testing.T) {
+	conf := logr.Config{Udp: "127.0.0.1:65001"}
+
+	logger, err := conf.NewLogger("concurrent-test.log")
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	defer logger.Close()
+
+	// Console output would only add noise to the test log.
+	logger.Console = false
+
+	const goroutines = 8
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				logger.Info("goroutine", id, "iteration", j)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

`rand.New` returns a `*rand.Rand` that is not safe for concurrent use, unlike the top-level functions of `math/rand`. `RandString` is called from `LogPackage.Chunkify` on every log record, so any application that logs from more than one goroutine races on the shared generator.

Under `-race` this shows up as a data race in `math/rand.(*rngSource).Uint64`. Without the detector it can corrupt the generator state and, with it, the chunk uid that receivers use to reassemble multi-part logs.

- Guard the generator with a mutex in `helpers.RandString`.
- Add a direct regression test for `RandString` under concurrent calls.
- Add a regression test that writes to a `Logger` from several goroutines — the shape the race actually appears in for consumers of this package.

Both new tests fail under `-race` without the fix and pass with it.

## Test plan

- [x] `go test -race ./...` — passes
- [x] `go vet ./...` — clean
- [x] Reverted the fix locally and confirmed both new tests fail under `-race` (12 race reports), confirming they catch the regression